### PR TITLE
Fix Moonbeam Dev node hang on startup problem

### DIFF
--- a/javascript/packages/orchestrator/src/metrics/index.ts
+++ b/javascript/packages/orchestrator/src/metrics/index.ts
@@ -114,8 +114,8 @@ function _extractMetrics(text: string): Metrics {
 
     // get the namespace of the key
     const parts = parsedLine.name.split("_");
-    const ns = parts[0];
-    const rawMetricNameWithOutNs = parts.slice(1).join("_");
+    const ns = parts[0] === 'moonbeam' ? `${parts[0]}_${parts[1]}` : parts[0];
+    const rawMetricNameWithOutNs = parts[0] === 'moonbeam' ? parts.slice(2).join("_") : parts.slice(1).join("_");
 
     let labelStrings = [];
     let labelStringsWithOutChain = [];

--- a/javascript/packages/orchestrator/src/paras-decorators/moonbeam.ts
+++ b/javascript/packages/orchestrator/src/paras-decorators/moonbeam.ts
@@ -118,11 +118,15 @@ async function addParaCustom(specPath: string, node: Node) {
   // parachainStaking
   if (!runtimeConfig?.parachainStaking) return;
 
-  const { sr_account, eth_account } = node.accounts;
+  const { eth_account } = node.accounts;
+  const stakingBond =  paraStakingBond || 1000000000000;
+
+  // Ensure collator account has enough balance to bond and add candidate
+  runtimeConfig.balances.balances.push([eth_account.address, stakingBond]);
 
   runtimeConfig.parachainStaking.candidates.push([
     eth_account.address,
-    paraStakingBond || 1000000000000,
+    stakingBond,
   ]);
 
   writeChainSpec(specPath, chainSpec);

--- a/javascript/packages/orchestrator/src/paras-decorators/moonbeam.ts
+++ b/javascript/packages/orchestrator/src/paras-decorators/moonbeam.ts
@@ -13,7 +13,7 @@ import { generateKeyForNode as _generateKeyForNode } from "../keys";
 import { ChainSpec, Node } from "../types";
 
 // track 1st staking as default;
-let paraStakingBond: number | undefined;
+let paraStakingBond: bigint | undefined;
 
 export type GenesisNodeKey = [string, string];
 
@@ -119,10 +119,11 @@ async function addParaCustom(specPath: string, node: Node) {
   if (!runtimeConfig?.parachainStaking) return;
 
   const { eth_account } = node.accounts;
-  const stakingBond =  paraStakingBond || 1000000000000;
+  const stakingBond =  paraStakingBond || BigInt('1000000000000000000');
 
   // Ensure collator account has enough balance to bond and add candidate
-  runtimeConfig.balances.balances.push([eth_account.address, stakingBond]);
+  runtimeConfig.balances.balances.push([eth_account.address, runtimeConfig.balances.balances[0][1]]);
+  // runtimeConfig.balances.balances.push([eth_account.address, BigInt('100000000000000000000')]);
 
   runtimeConfig.parachainStaking.candidates.push([
     eth_account.address,


### PR DESCRIPTION
An error occurred when parsing the promethus metrics namespace of moonbeam.
It will block the startup of the zombienet.
```
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Moonbase Local Testnet ⚙ Added Boot Nodes                                                                              │
├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ /ip4/127.0.0.1/tcp/53357/ws/p2p/12D3KooWCrSbwo29jtTXyGvNGTdbTAed8TE3WmHeaYxvyY5VoB7B                                   │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  zombie 	 checking node: alice +8s
  zombie::network-node reloading cache +0ms
  zombie::metrics fetching: http://127.0.0.1:53350/metrics +0ms
  zombie 	 checking node: bob +10ms
  zombie::network-node reloading cache +10ms
  zombie::metrics fetching: http://127.0.0.1:53354/metrics +9ms
  zombie 	 checking node: turing-col-1 +2ms
  zombie::network-node reloading cache +2ms
  zombie::metrics fetching: http://127.0.0.1:53356/metrics +2ms
  zombie 	 checking node: moonbase-col-1 +1ms
  zombie::network-node reloading cache +1ms

...

Error 	 fetching metrics from: http://127.0.0.1:53358/metrics
  zombie::network-node current value: undefined for metric process_start_time_seconds, keep trying... +2ms
```

Moonbeam metric key:
```
moonbeam_substrate_process_start_time_seconds{chain="moonbase_local"} 1677567828
```

Normal metric key:
```
substrate_process_start_time_seconds{chain="moonbase_local"} 1677567828
```

We can pass in the specified namespace here.

https://github.com/imstar15/zombienet/blob/5fa54b945c5dc5b68971c1b474a2ee1bca906bed/javascript/packages/orchestrator/src/orchestrator.ts#L846

Here is the `moonbase.toml` I use.

```
[settings]
provider = "native"
timeout = 1000

[relaychain]
default_command = "../polkadot/target/release/polkadot"
chain = "rococo-local"

[[relaychain.nodes]]
name = "alice"

[[relaychain.nodes]]
name = "bob"

[[parachains]]
id = 2114
cumulus_based = true
chain = "turing-dev"

[parachains.collator]
name = "turing-col-1"
command = "./target/release/oak-collator"
ws_port = 9946
rpc_port = 8855

[[parachains]]
id = 1000
cumulus_based = true
chain = "moonbase-local"

[parachains.collator]
name = "moonbase-col-1"
command = "../moonbeam/target/release/moonbeam"
ws_port = 9949
rpc_port = 8868
```

